### PR TITLE
Add : to prevent exit from printing when called from inside subshell

### DIFF
--- a/src/built_in/ft_exit.c
+++ b/src/built_in/ft_exit.c
@@ -6,7 +6,7 @@
 /*   By: junsan <junsan@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/06 12:05:58 by junsan            #+#    #+#             */
-/*   Updated: 2024/07/31 14:48:36 by junsan           ###   ########.fr       */
+/*   Updated: 2024/08/03 09:58:11 by junsan           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ int	ft_exit(t_info *info)
 	num_args = 0;
 	while (args[num_args])
 		num_args++;
-	if (num_args == 1)
+	if (num_args == 1 && !info->in_subshell)
 		(ft_putstr_fd("exit\n", 2), \
 		cleanup_and_exit(EXIT_SUCCESS, info->args, NULL, info));
 	if (num_args > 2)


### PR DESCRIPTION
>minishell PR message template and checklist. 
Please fill in/check all the items below and PR!

## Brief one-line summary of the fix
(Please write a short one-line summary/title of your fix here).
- Add : to prevent exit from printing when called from inside subshell
		 
## Detailed description of the fix
(Please write more details about your fix here)
- Implemetned feature for parsing capitalization

## Other questions
(Feel free to write any questions you have, things you noticed along the way, or anything else you want to share).
- The function logic seems to be too long, I wonder if there is a more efficient way to do it.(Example) 


## What's Next
- Write what's Next here

## CheckList
- [x] Check and follow the rules stated above
- [x] You have completed the necessary tests and verified that the functionality works properly.
- [x] You have written the code according to norminette.
